### PR TITLE
Azure-token-POC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Integrasjonstester for nais mikrotjenester i bidrag
 
 ## beskrivelse
 
-Kotlin gjør det enkelt å skape lett leselig tester og dette er satt opp med `Gherkin`-filer (*.feature) som har norsk tekst og ligger i `src/test/resources/<pakkenavn>`
+Kotlin gjør det enkelt å skape lett-leselige tester og dette er satt opp med `Gherkin`-filer (*.feature) som har norsk tekst og ligger i `src/test/resources/<pakkenavn>`
 
 BDD (Behaviour driven development) beskrives i `Gherkin`-filene (`*.featue`) som kjører automatiserte tester på bakgrunnen av funksjonaliteten som skal støttes.
 Eks: på en `gherkin` fil på norsk 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,31 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.ktor</groupId>
+      <artifactId>ktor-client-core</artifactId>
+      <version>1.3.2-1.4-M2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.ktor</groupId>
+      <artifactId>ktor-client-apache</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.ktor</groupId>
+      <artifactId>ktor-client-json</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.ktor</groupId>
+      <artifactId>ktor-client-jackson</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.natpryce</groupId>
+      <artifactId>konfig</artifactId>
+      <version>1.6.10.0</version>
+    </dependency>
 
     <!-- json -->
     <dependency>

--- a/src/main/kotlin/no/nav/bidrag/cucumber/azure/AzureAdClient.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/azure/AzureAdClient.kt
@@ -1,0 +1,25 @@
+package no.nav.bidrag.cucumber.azure
+
+import io.ktor.client.request.*
+import io.ktor.content.*
+import io.ktor.http.*
+
+class AzureAdClient(private val configuration: Configuration.AzureAd) {
+
+    suspend fun hentToken(): Token {
+        val azureAdUrl = "${configuration.authorityEndpoint}/${configuration.tenant}/oauth2/v2.0/token"
+        val formUrlEncode = listOf(
+            "client_id" to configuration.clientId,
+            "scope" to "openid ${configuration.clientId}/.default",
+            "client_secret" to configuration.clientSecret,
+            "username" to configuration.username,
+            "password" to configuration.password,
+            "grant_type" to "password"
+        ).formUrlEncode()
+
+        return apacheHttpClient.post {
+            url(azureAdUrl)
+            body = TextContent(formUrlEncode, ContentType.Application.FormUrlEncoded)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/bidrag/cucumber/azure/BidragSakClient.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/azure/BidragSakClient.kt
@@ -1,0 +1,32 @@
+package no.nav.bidrag.cucumber.azure
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.*
+import org.slf4j.LoggerFactory
+
+class BidragSakClient(
+    private val baseUrl: String,
+    private val azureAdClient: AzureAdClient
+) {
+
+    private val LOGGER = LoggerFactory.getLogger(BidragSakClient::class.java)
+
+    suspend fun henteSakMedGyldigToken(saksnr: String): HttpResponse {
+        val token = azureAdClient.hentToken();
+        return henteSak(saksnr, token.token)
+    }
+
+
+    private suspend fun henteSak(saksnr: String, token: String): HttpResponse {
+        LOGGER.info("Ber bidrag-sak om å hente sak med saksnr: $saksnr")
+
+        return httpClient.get {
+            url("$baseUrl/sak/$saksnr")
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+        }
+    }
+}
+
+

--- a/src/main/kotlin/no/nav/bidrag/cucumber/azure/BidragSakSteps.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/azure/BidragSakSteps.kt
@@ -1,0 +1,35 @@
+package no.nav.bidrag.cucumber.azure
+
+import io.cucumber.java8.No
+import io.ktor.client.statement.*
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+
+class BidragSakSteps() : No {
+
+    companion object {
+        private val configuration = Configuration()
+        private val azureAdClient = AzureAdClient(configuration.azureAd)
+        private val bidragSakClient = BidragSakClient(configuration.bidragSakBaseUrl, azureAdClient)
+
+        fun henteSak(saksnr : String) : HttpResponse =
+            runBlocking { bidragSakClient.henteSakMedGyldigToken(saksnr)}
+    }
+
+    private lateinit var saksnummer: String
+    private lateinit var resultat: HttpResponse
+
+    init {
+        Gitt("en sak med saksnr {string}") { saksnr: String ->
+            saksnummer = saksnr
+        }
+
+        Når("jeg henter denne saken") {
+            resultat = henteSak(saksnummer)
+        }
+
+        Så("skal resultatet være {int}") { svar: Integer ->
+            Assert.assertEquals(svar, resultat.status.value)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/bidrag/cucumber/azure/Configuration.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/azure/Configuration.kt
@@ -1,0 +1,51 @@
+package no.nav.bidrag.cucumber.azure
+
+import com.natpryce.konfig.*
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.io.FileNotFoundException
+
+private val LOGGER = LoggerFactory.getLogger(Configuration::class.java)
+
+private val defaultProperties = ConfigurationMap(
+    mapOf(
+        "AZURE_AUTHORITY_ENDPOINT" to "https://login.microsoftonline.com",
+        "AZURE_CLIENT_ID" to "61137106-058f-4b4c-8a65-11911f1bdd8f",
+        "AZURE_TENANT" to "966ac572-f5b7-4bbe-aa88-c76419c0f851",
+        "BIDRAG_SAK_BASE_URL" to "https://bidrag-sak-feature.dev.adeo.no/bidrag-sak",
+        "USERNAME" to "F_Z991656.E_Z991656@trygdeetaten.no",
+        "PASSWORD" to "Sjonkel8"
+    )
+)
+
+private val config = ConfigurationProperties.systemProperties() overriding
+        EnvironmentVariables overriding
+        defaultProperties
+
+private fun String.configProperty(): String = config[Key(this, stringType)]
+
+private fun String.readFile() =
+    try {
+        File(this).readText(Charsets.UTF_8)
+    } catch (err: FileNotFoundException) {
+        LOGGER.warn("Azure fil $this ikke funnet")
+        null
+    }
+
+data class Configuration(
+    val azureAd: AzureAd = AzureAd(),
+    val bidragSakBaseUrl: String = "BIDRAG_SAK_BASE_URL".configProperty(),
+    val password: String = "PASSWORD".configProperty(),
+) {
+
+    data class AzureAd(
+        val clientId: String = "/var/run/secrets/nais.io/azuread/client_id".readFile()
+            ?: "AZURE_CLIENT_ID".configProperty(),
+        val clientSecret: String = "/var/run/secrets/nais.io/azuread/client_secret".readFile()
+            ?: "AZURE_CLIENT_SECRET".configProperty(),
+        val username: String = "USERNAME".configProperty(),
+        val password: String = "PASSWORD".configProperty(),
+        val tenant: String = "AZURE_TENANT".configProperty(),
+        val authorityEndpoint: String = "AZURE_AUTHORITY_ENDPOINT".configProperty().removeSuffix("/")
+    )
+}

--- a/src/main/kotlin/no/nav/bidrag/cucumber/azure/HttpClient.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/azure/HttpClient.kt
@@ -1,0 +1,40 @@
+package no.nav.bidrag.cucumber.azure
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import io.ktor.client.*
+import io.ktor.client.engine.apache.*
+import io.ktor.client.features.json.*
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner
+import java.net.ProxySelector
+
+//Bruker apache mot Azure da den støtter proxy.
+internal val apacheHttpClient = HttpClient(Apache) {
+    install(JsonFeature) {
+        serializer = JacksonSerializer {
+            this.registerModule(JavaTimeModule())
+                .configure(SerializationFeature.INDENT_OUTPUT, true)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
+        }
+    }
+
+    engine {
+        socketTimeout = 45000
+
+        customizeClient { setRoutePlanner(SystemDefaultRoutePlanner(ProxySelector.getDefault())) }
+    }
+}
+
+internal val httpClient = HttpClient {
+    install(JsonFeature) {
+        serializer = JacksonSerializer {
+            this.registerModule(JavaTimeModule())
+                .configure(SerializationFeature.INDENT_OUTPUT, true)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/bidrag/cucumber/azure/Token.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/azure/Token.kt
@@ -1,0 +1,18 @@
+package no.nav.bidrag.cucumber.azure
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDateTime
+
+data class Token(
+    @JsonProperty(value = "access_token", required = true)
+    val token: String,
+    @JsonProperty(value = "token_type", required = true)
+    val type: String,
+    @JsonProperty(value = "expires_in", required = true)
+    val expiresIn: Int
+) {
+
+    private val expirationTime: LocalDateTime = LocalDateTime.now().plusSeconds(expiresIn - 20L)
+
+    fun hasExpired(): Boolean = expirationTime.isBefore(LocalDateTime.now())
+}

--- a/src/main/resources/no/nav/bidrag/cucumber/nais/beregn/azure/sikkerhet.feature
+++ b/src/main/resources/no/nav/bidrag/cucumber/nais/beregn/azure/sikkerhet.feature
@@ -1,0 +1,10 @@
+# language: no
+Egenskap:  bidrag-sak med Azure-token
+  Tester bidrag-sak
+
+  Scenario: Teste bidrag-sak med token fra Azure
+    Gitt en sak med saksnr "1900000"
+    Når jeg henter denne saken
+    Så skal resultatet være 200
+
+


### PR DESCRIPTION
Legge til POC for henting av id-token fra Azure AD og bruke dette i kall mot bidrag-sak

Dette er ment som et utgangspunkt for å hente Azure AD token for tester som kjøres i Cucumber. PR-en er ikke tenkt å merges til main.